### PR TITLE
Expand given file path before changing directories

### DIFF
--- a/backup/crowbar-backup
+++ b/backup/crowbar-backup
@@ -262,7 +262,7 @@ function help()
   echo " If <FILE> is omitted it defaults to $FILEDEF"
 }
 
-FILE=${2:-$FILEDEF}
+FILE=$(realpath ${2:-$FILEDEF})
 declare -a action
 action=( $@ )
 if [[ ${#action[@]} < 1 ]] ; then


### PR DESCRIPTION
Otherwise when the path given for backup/restore is relative,
it is being resolved to /, which is unexpected for the user.
