### PR TITLE
remove useless dns test

### DIFF
--- a/backup/crowbar-backup
+++ b/backup/crowbar-backup
@@ -114,10 +114,6 @@ function check_resolv_conf
   # check if DNS servers are available and can resolve domain names
   echo "Check if DNS is available and domain resolution works"
   for ns in `grep "^\s*nameserver" /etc/resolv.conf | sed -e "s/\s*nameserver \([[:digit:]\.]\+\)[^[:digit:]\.]*/\1/" ` ; do
-    if ! netcat -zu $ns 53 ; then
-      echo "Error: Nameserver '$ns' is not available. Please reconfigure /etc/resolv.conf manually."
-      exit 1
-    fi
     if ! getent hosts "$HOSTTEST" >/dev/null; then
       echo "Error: Nameserver '$ns' can not resolve or ping $HOSTTEST. Please reconfigure /etc/resolv.conf manually"
       exit 1


### PR DESCRIPTION
from netcat manpage : 

CAVEATS
UDP port scans using the -uz combination of flags will always report success irrespective of the target machine's state.