### PR TITLE
Backup /etc/crowbar.install.key too

### DIFF
--- a/backup/crowbar-backup
+++ b/backup/crowbar-backup
@@ -59,7 +59,7 @@ function echo_summary ()
 
 # files and directories to be backuped
 CHEFFILES="etc/chef var/lib/couchdb/chef.couch var/lib/chef/cookbook_index"
-CROWBARFILES="etc/crowbar var/lib/crowbar opt/dell/crowbar_framework/config/client.pem"
+CROWBARFILES="etc/crowbar etc/crowbar.install.key var/lib/crowbar opt/dell/crowbar_framework/config/client.pem"
 TFTPFILES="srv/tftpboot/validation.pem srv/tftpboot/nodes"
 ROOTFILES="root/.chef root/.ssh root/.gnupg"
 BFILES="$ROOTFILES $CHEFFILES $CROWBARFILES $TFTPFILES etc/resolv.conf.forwarders"


### PR DESCRIPTION
It's obviously needed by crowbar.

(cherry picked from commit 24e9234a73220ae4a0b58af947c56846d94ef9e4)